### PR TITLE
Support override path to support serverless (GCP/Azure/AWS)

### DIFF
--- a/src/buffer_utils.js
+++ b/src/buffer_utils.js
@@ -72,16 +72,16 @@ module.exports.base64str2webp = (base64str,image_type,option) => {
 * @param  {string} option
  */
 // convert image buffer  to webp buffer
-module.exports.buffer2webp = (buffer,image_type,option) => {
+module.exports.buffer2webp = (buffer,image_type,option,overide_path) => {
 
     let buf = Buffer.from(buffer);
     let base64str = buf.toString('base64');
 
     let filename = String(Math.floor(Math.random() * 10000000000) + 1)
 
-    let input_file_path = `${temp_path()}${filename}.${image_type}`;
+    let input_file_path = `${temp_path(overide_path)}${filename}.${image_type}`;
 
-    let webp_image_path  = `${temp_path()}${filename}.webp`;
+    let webp_image_path  = `${temp_path(overide_path)}${filename}.webp`;
 
     let status = base64_to_image(base64str,input_file_path)
 

--- a/src/temp_path.js
+++ b/src/temp_path.js
@@ -1,7 +1,12 @@
 
 const path = require('path');
 //get os type then return path of respective platform library 
-const temp_files=function() {
+const temp_files=function(overide_path) {
+    // Support override path
+    if ((process.platform === 'darwin' || process.platform === 'linux' || (process.platform === 'win32' && process.arch === 'x64')) && overide_path) {
+        return overide_path;
+    }
+
     if (process.platform === 'darwin') {
         
         return path.join(__dirname, "../", "/temp/");//return osx library path

--- a/src/webpconverter.js
+++ b/src/webpconverter.js
@@ -28,11 +28,11 @@ module.exports.str2webpstr = (base64str,image_type,option) => {
 };
 
 //convert buffer to webp buffer
-module.exports.buffer2webpbuffer = (buffer,image_type,option) => {
+module.exports.buffer2webpbuffer = (buffer,image_type,option,overide_path=null) => {
   // buffer of image
   // buffer image type jpg,png ...
   //option: options and quality,it should be given between 0 to 100
-  return buffer_utils.buffer2webp(buffer,image_type,option).then(function(val) {
+  return buffer_utils.buffer2webp(buffer,image_type,option,overide_path).then(function(val) {
     return val
   });
 };


### PR DESCRIPTION
- Support override path for the buffer2webpbuffer method
- The option should be overridable since node_modules is inaccessible due to symlinks
- Instead use the %TEMP% path for Azure Functions where application is allowed to read/write to by default