### PR TITLE
Support quiet mode

### DIFF
--- a/src/webpconverter.js
+++ b/src/webpconverter.js
@@ -46,7 +46,7 @@ module.exports.cwebp = (input_image,output_image,option) => {
 
 const query = `${option} "${input_image}" -o "${output_image}"`; //command to convert image 
 
-console.log(query);
+if(!query.includes('-quiet')) console.log(query);
 
 //enwebp() return which platform webp library should be used for conversion
 return new Promise((resolve, reject) => {
@@ -71,7 +71,7 @@ module.exports.dwebp = (input_image,output_image,option) => {
 
 const query = `"${input_image}" ${option} "${output_image}"`;//command to convert image  
 
-console.log(query);
+if(!query.includes('-quiet')) console.log(query);
 
 //dewebp() return which platform webp library should be used for conversion
 return new Promise((resolve, reject) => {


### PR DESCRIPTION
Hi :)
This package is great, it does everything I need, except for the fact that it pollutes my console with query strings every time I use it. If I can't make the queries go away, I'll have to use something else.

I propose this change, that would simply stop printing the queries if the `-quiet` flag is set on the query. There are many other ways this could be done, but this would solve my issue. Let me know if you want it to be implemented in another way, I'll see if I can do that instead.

I believe this change closes #9