### PR TITLE
Better error handling, fixes Promise logic, fixed formatting and fixes readme example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ For converting gif image to webp, please read this documentation [gif2webp Conve
 For creating animated webp image using webp images, please read this documentation [webpmux Muxer](https://developers.google.com/speed/webp/docs/webpmux)
 
 
-## What's New 
+## What's New
+* Better error handling, fixes missing promise rejects. Removes console logging.
 * logging options added
 
 # How to use

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ const webp=require('webp-converter');
 //pass input image(.jpeg,.pnp .....) path ,output image(give path where to save and image file name with .webp extension)
 //pass option(read  documentation for options)
 
-//cwebp(input,output,option)
+// cwebp(input, output, option, loggingOption)
+// Default logging level is --silent
 
-const result = webp.cwebp("nodejs_logo.jpg","nodejs_logo.webp","-q 80",logging="-v");
+const result = webp.cwebp("nodejs_logo.jpg","nodejs_logo.webp","-q 80","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -123,9 +124,10 @@ const webp=require('webp-converter');
 
 //pass input image(.webp image) path ,output image(.jpeg,.pnp .....)
 
-//dwebp(input,output,option)
+// dwebp(input, output, option, loggingOption)
+// Default logging level is --silent 
 
-const result = webp.dwebp("nodejs_logo.webp","nodejs_logo.jpg","-o",logging="-v");
+const result = webp.dwebp("nodejs_logo.webp","nodejs_logo.jpg","-o","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -143,9 +145,10 @@ const webp=require('webp-converter');
 //pass input image(.gif) path ,output image(give path where to save and image file name with .webp extension)
 //pass option(read  documentation for options)
 
-//gwebp(input,output,option)
+// gwebp(input, output, option, loggingOption)
+// Default logging level is --silent
 
-const result = webp.gwebp("linux_logo.gif","linux_logo.webp","-q 80",logging="-v");
+const result = webp.gwebp("linux_logo.gif","linux_logo.webp","-q 80","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -167,9 +170,10 @@ const webp=require('webp-converter');
 //for XMP metadata: xmp
 //for EXIF metadata: exif
 
-//webpmux_add(input,output,option_profile,set_option)
+//webpmux_add(input,output,option_profile,set_option,loggingOption)
+// Default logging level is --silent
 
-const result = webp.webpmux_add("in.webp","icc_container.webp","image_profile.icc","icc",logging="-v");
+const result = webp.webpmux_add("in.webp","icc_container.webp","image_profile.icc","icc","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -189,9 +193,10 @@ const webp=require('webp-converter');
 //for XMP metadata: xmp
 //for EXIF metadata: exif
 
-//webpmux_extract(input,output,option)
+//webpmux_extract(input,output,option,loggingOption)
+// Default logging level is --silent
 
-const result = webp.webpmux_extract("anim_container.webp","image_profile.icc","icc",logging="-v");
+const result = webp.webpmux_extract("anim_container.webp","image_profile.icc","icc","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -211,9 +216,10 @@ const webp=require('webp-converter');
 //for XMP metadata: xmp
 //for EXIF metadata: exif
 
-//webpmux_strip(input,output,option)
+//webpmux_strip(input,output,option,loggingOption)
+// Default logging level is --silent
 
-const result = webp.webpmux_strip("icc_container.webp","without_icc.webp","icc",logging="-v");
+const result = webp.webpmux_strip("icc_container.webp","without_icc.webp","icc","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -252,12 +258,13 @@ e.g 255,255,255,255
 Background color of the canvas. Where: A, R, G and B are integers in the range 0 to 255 specifying the Alpha, Red, Green and Blue component values respectively [Default: 255,255,255,255].
 */
 
-//webpmux_animate(input_images_array,output,bgcolor)
+//webpmux_animate(input_images_array,output,bgcolor,loggingOption)
+// Default logging level is --silent
 
 const webp=require('webp-converter');
 
 let input=[{"path":"./frames/tmp-0.webp","offset":"+100"},{"path":"./frames/tmp-1.webp", "offset":"+100"},{"path":"./frames/tmp-2.webp","offset":"+100"}];
-const result = webp.webpmux_animate(input,"anim_container.webp","10","255,255,255,255",logging="-v");
+const result = webp.webpmux_animate(input,"anim_container.webp","10","255,255,255,255","-v");
 result.then((response) => {
 	console.log(response);
   });
@@ -273,9 +280,10 @@ const webp=require('webp-converter');
 
 //pass input image(.webp image) path ,output image and frame number
 
-//webpmux_getframe(input,ouput,frame number)
+//webpmux_getframe(input,ouput,frame number,loggingOption)
 
-const result = webp.webpmux_getframe("anim_container.webp","frame_2.webp","2",logging="-v");
+
+const result = webp.webpmux_getframe("anim_container.webp","frame_2.webp","2","-v");
 result.then((response) => {
 	console.log(response);
   });

--- a/src/buffer_utils.js
+++ b/src/buffer_utils.js
@@ -31,7 +31,7 @@ const base64_to_image = (base64str,path) =>{
         if (error) {
           throw error;
         } else {
-          console.log('File created from base64 string!');
+          //console.log('File created from base64 string!');
         }
       });
     return true;
@@ -65,7 +65,7 @@ module.exports.base64str2webp = (base64str,image_type,option,extra_path) => {
           return webp_base64str
       });
       }else{
-        console.log("Failed")
+        throw Error("Failed to convert base64str to webp");
       }
 }
 /**
@@ -89,17 +89,17 @@ module.exports.buffer2webp = (buffer,image_type,option,extra_path) => {
     let status = base64_to_image(base64str,input_file_path)
 
     if(status){
-    const result = webp.cwebp(input_file_path,webp_image_path,option);
-    return result.then((response) => {
+      const result = webp.cwebp(input_file_path,webp_image_path,option);
+      return result.then((response) => {
         let webp_buffer = encode_image(webp_image_path,"buffer")
 
         fs.unlinkSync(input_file_path);
         fs.unlinkSync(webp_image_path);
 
         return webp_buffer
-    });
-    }else{
-      console.log("Failed")
+      });
+    } else {
+      throw Error("Failed to convert buffer to webp buffer");
     }
     
 }

--- a/src/buffer_utils.js
+++ b/src/buffer_utils.js
@@ -15,7 +15,7 @@ function encode_image(filepath,type) {
         let base64 = buf.toString('base64');
         // console.log('Base64 ' + filepath + ': ' + base64);
         return base64;
-    }else{
+    } else {
         return buf
     }
   }
@@ -30,8 +30,6 @@ const base64_to_image = (base64str,path) =>{
     fs.writeFileSync(path, buf, function(error) {
         if (error) {
           throw error;
-        } else {
-          //console.log('File created from base64 string!');
         }
       });
     return true;
@@ -64,7 +62,7 @@ module.exports.base64str2webp = (base64str,image_type,option,extra_path) => {
   
           return webp_base64str
       });
-      }else{
+      } else {
         throw Error("Failed to convert base64str to webp");
       }
 }

--- a/src/cwebp.js
+++ b/src/cwebp.js
@@ -13,11 +13,11 @@ const enwebp=function() {
         if (process.arch === 'x64') {
             return path.join(__dirname, "../", "\\bin\\libwebp_win64\\bin\\cwebp.exe");//return windows 64bit library path
         } else {
-            console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
+            throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
         }
 
     } else {
-        console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
+        throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
     }
 };
 module.exports = enwebp

--- a/src/dwebp.js
+++ b/src/dwebp.js
@@ -15,11 +15,11 @@ const dwebp=function() {
         if (process.arch === 'x64') {
             return path.join(__dirname, "../", "\\bin\\libwebp_win64\\bin\\dwebp.exe");//return windows 64bit library path
         } else {
-            console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
+            throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
         }
 
     } else {
-        console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
+        throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
     }
 };
 

--- a/src/gwebp.js
+++ b/src/gwebp.js
@@ -14,11 +14,11 @@ const gifwebp=function() {
         if (process.arch === 'x64') {
             return path.join(__dirname, "../", "\\bin\\libwebp_win64\\bin\\gif2webp.exe");//return windows 64bit library path
         } else {
-            console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
+            throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
         }
 
     } else {
-        console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
+        throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
     }
 };
 module.exports = gifwebp

--- a/src/webpconverter.js
+++ b/src/webpconverter.js
@@ -32,9 +32,7 @@ module.exports.buffer2webpbuffer = (buffer,image_type,option,extra_path) => {
   // buffer of image
   // buffer image type jpg,png ...
   //option: options and quality,it should be given between 0 to 100
-  return buffer_utils.buffer2webp(buffer,image_type,option,extra_path).then(function(val) {
-    return val
-  });
+  return buffer_utils.buffer2webp(buffer,image_type,option,extra_path);
 };
 
 //now convert image to .webp format 
@@ -51,9 +49,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${enwebp()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -75,9 +76,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${dewebp()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 
@@ -100,9 +104,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${gifwebp()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -125,9 +132,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -146,9 +156,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -167,9 +180,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -198,9 +214,12 @@ return new Promise((resolve, reject) => {
   //execute command 
   exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
   if (error) {
-   console.warn(error);
+    reject(error);
+  } else if (stderr){
+    reject(stderr);
+  } else {
+    resolve(stdout);
   }
-  resolve(stdout? stdout : stderr);
  });
 });
 };
@@ -218,11 +237,14 @@ const query = `-get frame ${frame_number} "${input_image}" -o "${output_image}" 
 //webpmux() return which platform webp library should be used for conversion
 return new Promise((resolve, reject) => {
   //execute command 
-exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
-  if (error) {
-   console.warn(error);
-  }
-  resolve(stdout? stdout : stderr);
- });
+  exec(`"${webpmux()}"`,query.split(/\s+/),{ shell: true }, (error, stdout, stderr) => {
+    if (error) {
+      reject(error);
+    } else if (stderr){
+      reject(stderr);
+    } else {
+      resolve(stdout);
+    }
+  });
 });
 };

--- a/src/webpconverter.js
+++ b/src/webpconverter.js
@@ -6,7 +6,7 @@ const gifwebp=require('./gwebp.js');//get gif2webp module(convert git image to w
 const webpmux=require('./webpmux.js');//get webpmux module(convert non animated webp images to animated webp)
 const buffer_utils = require('./buffer_utils.js');//get buffer utilities 
 
-//permission issue in Linux and macOS
+// Permission issue in Linux and MacOS
 module.exports.grant_permission = () => {
 
 const arr = [enwebp(), dewebp(), gifwebp(),webpmux()];
@@ -17,20 +17,20 @@ arr.forEach(exe_path => {
 
 };
 
-//convert base64 to webp base64
+// Convert base64 to webp base64
 module.exports.str2webpstr = (base64str,image_type,option,extra_path) => {
   // base64str of image
-  // base64str image type jpg,png ...
+  // base64str image type jpg, png ...
   //option: options and quality,it should be given between 0 to 100
   return buffer_utils.base64str2webp(base64str,image_type,option,extra_path).then(function(val) {
     return val
   });
 };
 
-//convert buffer to webp buffer
+// Convert buffer to webp buffer
 module.exports.buffer2webpbuffer = (buffer,image_type,option,extra_path) => {
   // buffer of image
-  // buffer image type jpg,png ...
+  // buffer image type jpg, png ...
   //option: options and quality,it should be given between 0 to 100
   return buffer_utils.buffer2webp(buffer,image_type,option,extra_path);
 };
@@ -38,9 +38,9 @@ module.exports.buffer2webpbuffer = (buffer,image_type,option,extra_path) => {
 //now convert image to .webp format 
 module.exports.cwebp = (input_image,output_image,option,logging='-quiet') => {
 
-// input_image: input image(.jpeg, .pnp ....)
-//output_image: output image .webp 
-//option: options and quality,it should be given between 0 to 100
+// input_image: input image(.jpeg, .png ...)
+// output_image: output image .webp 
+// option: options and quality,it should be given between 0 to 100
 
 const query = `${option} "${input_image}" -o "${output_image}" "${logging}"`; //command to convert image 
 
@@ -61,12 +61,12 @@ return new Promise((resolve, reject) => {
 
 /******************************************************* dwebp *****************************************************/
 
-//now convert .webp to other image format 
+// Convert .webp to other image format 
 module.exports.dwebp = (input_image,output_image,option,logging='-quiet') => {
 
 // input_image: input image .webp
-//output_image: output image(.jpeg, .pnp ....)
-//option: options and quality,it should be given between 0 to 100
+// output_image: output image(.jpeg, .png ...)
+// option: options and quality,it should be given between 0 to 100
 
 const query = `"${input_image}" ${option} "${output_image}" "${logging}"`;//command to convert image  
 
@@ -89,13 +89,12 @@ return new Promise((resolve, reject) => {
 
 /******************************************************* gif2webp *****************************************************/
 
-//now convert .gif image to .webp format 
+// Convert .gif image to .webp format 
 module.exports.gwebp = (input_image,output_image,option,logging='-quiet') => {
 
-// input_image: input image(.jpeg, .pnp ....)
-//output_image: /output image .webp 
-//option: options and quality,it should be given between 0 to 100
-
+// input_image: input image(.jpeg, .png ...)
+// output_image: /output image .webp 
+// option: options and quality,it should be given between 0 to 100
 
 const query = `${option} "${input_image}" -o "${output_image}" "${logging}"`;//command to convert image
 
@@ -121,9 +120,9 @@ return new Promise((resolve, reject) => {
 module.exports.webpmux_add = (input_image,output_image,icc_profile,option,logging='-quiet') => {
 
 // input_image: input image(.webp)
-//output_image: output image .webp  
-//icc_profile: icc profile
-//option: get or set option (icc,xmp,exif)
+// output_image: output image .webp  
+// icc_profile: icc profile
+// option: get or set option (icc,xmp,exif)
 
 const query = `-set ${option} ${icc_profile} "${input_image}" -o "${output_image}" "${logging}"`;
 
@@ -147,7 +146,7 @@ return new Promise((resolve, reject) => {
 module.exports.webpmux_extract = (input_image,icc_profile,option,logging='-quiet') => {
 
 // input_image: input image(.webp) 
-//icc_profile: icc profile
+// icc_profile: icc profile
 
 const query = `-get ${option} "${input_image}" -o ${icc_profile} "${logging}"`;
 
@@ -171,7 +170,7 @@ return new Promise((resolve, reject) => {
 module.exports.webpmux_strip = (input_image,output_image,option,logging='-quiet') => {
 
 // input_image: input image(.webp) 
-//output_image: output image .webp
+// output_image: output image .webp
 
 const query = `-strip ${option} "${input_image}" -o "${output_image}" "${logging}"`;
 
@@ -195,9 +194,9 @@ return new Promise((resolve, reject) => {
 module.exports.webpmux_animate = (input_images,output_image,loop,bgcolor,logging='-quiet') => {
 
 // input_images: array of image(.webp) 
-//output_image: animatedimage .webp
-//loop:Loop the frames n number of times
-//bgcolor: Background color of the canvas
+// output_image: animatedimage .webp
+// loop:Loop the frames n number of times
+// bgcolor: Background color of the canvas
 
 let files=`-frame ${input_images[0]["path"]} ${input_images[0]["offset"]}`;
 
@@ -229,8 +228,8 @@ return new Promise((resolve, reject) => {
 module.exports.webpmux_getframe = (input_image,output_image,frame_number,logging='-quiet') => {
 
 // input_image: input image(.webp) 
-//output_image: output image .webp
-//frame_number: frame number
+// output_image: output image .webp
+// frame_number: frame number
 
 const query = `-get frame ${frame_number} "${input_image}" -o "${output_image}" "${logging}"`;
 

--- a/src/webpmux.js
+++ b/src/webpmux.js
@@ -15,10 +15,10 @@ const webpmux=function() {
         if (process.arch === 'x64') {
             return path.join(__dirname, "../", "\\bin\\libwebp_win64\\bin\\webpmux.exe");//return windows 64bit library path
         } else {
-            console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
+            throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message
         }
     } else {
-        console.log('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
+        throw Error('Unsupported platform:', process.platform, process.arch);//show unsupported platform message 
     }
 };
 module.exports = webpmux


### PR DESCRIPTION
This pull fixes the Promise logic. The previous code didn't reject errors, therefore users couldn't do a promise catch(error) when the library failed to do a conversion. Also using console.log would dirty up the terminal, which might break custom logging libraries and logging to a supervisor. Console.log has been replaced with throw Error with better error messages to point the user towards the error. The throw Error clauses also works with Promise catch.

I have tested the cwebp but the other functions follow the same logic.